### PR TITLE
Fixes 'no output' issue from #3

### DIFF
--- a/bin/rx
+++ b/bin/rx
@@ -110,7 +110,12 @@ if (program.compat && program.lite) {
   requiredStart = require('../lib/header');
 }
 
-var totalFiles = requiredStart.concat(fileLocations, requiredEnd);
+var path = require('path');
+var totalFiles = requiredStart
+  .concat(fileLocations, requiredEnd)
+  .map(function (fileLocation) {
+    return path.join(__dirname, '..', fileLocation);
+  });
 
 var outputFile = 'rx.custom.js';
 var outputMinFile = 'rx.custom.min.js';


### PR DESCRIPTION
## TL;DR

No output file was created because the source files couldn't be found on disk. The source files couldn't be found because the paths in `lib/dependencies` are written relative to the project root, not the `rx` script. This alters the paths to be relative to the `rx` script.
## Output Before

```
○ ~/Sites/rx ‣ ls -alh
total 0
drwxr-xr-x    2 jschulz  staff    68B Jan  6 16:40 .
drwxr-xr-x  262 jschulz  staff   8.7K Jan  6 14:24 ..

○ ~/Sites/rx ‣ rx --lite --methods map,filter,fromevent
Requested operator map
Alias for map found - select
Adding operator select
Requested operator filter
Alias for filter found - where
Adding operator where
Requested operator fromevent
Adding operator fromevent
Adding operator fromeventpattern
Adding operator publish
Adding operator multicast
Adding operator connectableobservable

○ ~/Sites/rx ‣ ls -alh
total 0
drwxr-xr-x    2 jschulz  staff    68B Jan  6 16:40 .
drwxr-xr-x  262 jschulz  staff   8.7K Jan  6 14:24 ..
```
## Output After

```
○ ~/Sites/rx ‣ ls -alh
total 0
drwxr-xr-x    2 jschulz  staff    68B Jan  6 16:40 .
drwxr-xr-x  262 jschulz  staff   8.7K Jan  6 14:24 ..

○ ~/Sites/rx ‣ rx --lite --methods map,filter,fromevent
Requested operator map
Alias for map found - select
Adding operator select
Requested operator filter
Alias for filter found - where
Adding operator where
Requested operator fromevent
Adding operator fromevent
Adding operator fromeventpattern
Adding operator publish
Adding operator multicast
Adding operator connectableobservable

○ ~/Sites/rx ‣ ls -alh
total 0
drwxr-xr-x    3 jschulz  staff   102B Jan  6 16:40 .
drwxr-xr-x  262 jschulz  staff   8.7K Jan  6 14:24 ..
drwxr-xr-x    4 jschulz  staff   136B Jan  6 16:40 build

○ ~/Sites/rx ‣ ls -alh build/
total 232
drwxr-xr-x  4 jschulz  staff   136B Jan  6 16:40 .
drwxr-xr-x  3 jschulz  staff   102B Jan  6 16:40 ..
-rw-r--r--  1 jschulz  staff    86K Jan  6 16:40 rx.custom.js
-rw-r--r--  1 jschulz  staff    27K Jan  6 16:40 rx.custom.min.js
```
